### PR TITLE
Add SelectionListener and KeyListener to Swt::Events

### DIFF
--- a/lib/swt/full.rb
+++ b/lib/swt/full.rb
@@ -80,6 +80,8 @@ module Swt
     import org.eclipse.swt.events.KeyEvent
     import org.eclipse.swt.events.MouseListener
     import org.eclipse.swt.events.MouseTrackListener
+    import org.eclipse.swt.events.SelectionListener
+    import org.eclipse.swt.events.KeyListener
   end
 
   import org.eclipse.swt.browser.Browser


### PR DESCRIPTION
The SelectionListener and KeyListener interfaces have more than one method, so using add_selection_listener or add_key_listener with a block isn't always enough, since that block gets called for **any** method. JRuby provides the impl method to handle these cases. With it, you can do something like this:

```
foo.add_key_listener(Swt::Events::KeyListener.impl { |method, *args| ... })
```

Whenever any method is called on that interface, it also passes the name of the method.

However, Swt::Events::KeyListener and Swt::Events::SelectionListener weren't available, so I added them.
