### PR TITLE
Recognize 'amd64' arch on OS X

### DIFF
--- a/lib/swt/jar_loader.rb
+++ b/lib/swt/jar_loader.rb
@@ -8,19 +8,19 @@ module Swt
   def self.relative_jar_path
     case Config::CONFIG["host_os"]
     when /darwin/i
-      if %w(amd64 x84_64).include? Config::CONFIG["host_cpu"]
+      if %w(amd64 x86_64).include? Config::CONFIG["host_cpu"]
         '../../../vendor/swt/swt-osx64'
       else
         '../../../vendor/swt/swt-osx32'
       end
     when /linux/i
-      if %w(amd64 x84_64).include? Config::CONFIG["host_cpu"]
+      if %w(amd64 x86_64).include? Config::CONFIG["host_cpu"]
         '../../../vendor/swt/swt-linux64'
       else
         '../../../vendor/swt/swt-linux32'
       end
     when /windows|mswin/i
-      if %w(amd64 x84_64).include? Config::CONFIG["host_cpu"]
+      if %w(amd64 x86_64).include? Config::CONFIG["host_cpu"]
         '../../../vendor/swt/swt-win64'
       else
         '../../../vendor/swt/swt-win32'


### PR DESCRIPTION
After I upgraded to Mountain Lion, my swt started to fail under jruby-1.6.7, because it was trying to load the 32-bit jar. This fix allows the loader to recognize 'amd64' as well as 'x86_64' for the 'host_cpu' string.

Here's how my 'host_cpu' looks:

```
$ rvm use jruby-1.6.7
Using /Users/eric/.rvm/gems/jruby-1.6.7
$ irb
jruby-1.6.7 :001 > Config::CONFIG['host_cpu']
 => "amd64" 
jruby-1.6.7 :002 > quit
$ rvm use jruby-1.7.0.preview2
Using /Users/eric/.rvm/gems/jruby-1.7.0.preview2
$ irb
jruby-1.7.0.preview2 :001 > Config::CONFIG['host_cpu']
(irb):1: Use RbConfig instead of obsolete and deprecated Config.
 => "x86_64" 
jruby-1.7.0.preview2 :002 > quit
$ 
```
