### PR TITLE
Use expand_path to locate JFace JARs

### DIFF
--- a/lib/swt/full.rb
+++ b/lib/swt/full.rb
@@ -99,7 +99,7 @@ module Swt
 end
 
 module JFace
-  Dir[File.dirname(__FILE__) + "/../../vendor/jface/*.jar"].each do |jar_fn|
+  Dir[File.expand_path "../../../vendor/jface/*.jar", __FILE__].each do |jar_fn|
     require jar_fn
   end
 


### PR DESCRIPTION
When using Warbler and bundling the swt gem into a JAR,
JRuby was unable to find the JFace JARs, which were collected
using File.dirname. JRuby _could_ find the SwtBot
extensions, which were collected using File.expand_path. This commit
simply uses the File.expand_path strategy for both scenarios.

Here's a sample failure. It fails on the first import, because none of the jars are loaded.

```
huckle:shoes-warbler eric$ java -XstartOnFirstThread -Djruby.compat.version=1.9 -jar shoes-warbler.jar 
NameError: cannot load Java class org.eclipse.jface.viewers.ColumnViewerToolTipSupport
  get_proxy_or_package_under_package at org/jruby/javasupport/JavaUtilities.java:54
                      method_missing at file:/var/folders/cs/fj2g74691w76kp1z90xbdq6h0000gn/T/jruby4568188648145670371extract/jruby-core-1.6.7.2.jar!/builtin/javasupport/java.rb:51
                             Viewers at file:/Users/eric/code/shoes-warbler/shoes-warbler.jar!/gems/swt-0.13/lib/swt/full.rb:107
                               JFace at file:/Users/eric/code/shoes-warbler/shoes-warbler.jar!/gems/swt-0.13/lib/swt/full.rb:106
                              (root) at file:/Users/eric/code/shoes-warbler/shoes-warbler.jar!/gems/swt-0.13/lib/swt/full.rb:101
                             require at org/jruby/RubyKernel.java:1042
                             require at file:/Users/eric/code/shoes-warbler/shoes-warbler.jar!/gems/swt-0.13/lib/swt/full.rb:36
                              (root) at file:/Users/eric/code/shoes-warbler/shoes-warbler.jar!/gems/swt-0.13/lib/swt.rb:3
                             require at org/jruby/RubyKernel.java:1042
                             require at file:/Users/eric/code/shoes-warbler/shoes-warbler.jar!/gems/swt-0.13/lib/swt.rb:36
                              (root) at file:/Users/eric/code/shoes-warbler/shoes-warbler.jar!/gems/shoes-4.0.0.pre1/lib/shoes/swt.rb:2
                             require at org/jruby/RubyKernel.java:1042
                             require at file:/Users/eric/code/shoes-warbler/shoes-warbler.jar!/gems/shoes-4.0.0.pre1/lib/shoes/swt.rb:36
                            backend= at file:/Users/eric/code/shoes-warbler/shoes-warbler.jar!/gems/shoes-4.0.0.pre1/lib/shoes/configuration.rb:20
                              (root) at file:/Users/eric/code/shoes-warbler/shoes-warbler.jar!/shoes-warbler/bin/hello_from_warbler:3
                                load at org/jruby/RubyKernel.java:1068
                              (root) at file:/Users/eric/code/shoes-warbler/shoes-warbler.jar!/shoes-warbler/bin/hello_from_warbler:1
                             require at org/jruby/RubyKernel.java:1042
                             require at file:/Users/eric/code/shoes-warbler/shoes-warbler.jar!/META-INF/main.rb:36
                              (root) at <script>:3
```
