### PR TITLE
Fix loader for 64bit platforms, and fix RbConfig warning.

### DIFF
--- a/lib/swt/jar_loader.rb
+++ b/lib/swt/jar_loader.rb
@@ -6,21 +6,21 @@ module Swt
   end
   
   def self.relative_jar_path
-    case Config::CONFIG["host_os"]
+    case RbConfig::CONFIG["host_os"]
     when /darwin/i
-      if Config::CONFIG["host_cpu"] == "x86_64"
+      if RbConfig::CONFIG["host_cpu"] == "x86_64"
         '../../../vendor/swt/swt-osx64'
       else
         '../../../vendor/swt/swt-osx32'
       end
     when /linux/i
-      if %w(amd64 x84_64).include? Config::CONFIG["host_cpu"]
+      if %w(amd64 x86_64).include? RbConfig::CONFIG["host_cpu"]
         '../../../vendor/swt/swt-linux64'
       else
         '../../../vendor/swt/swt-linux32'
       end
     when /windows|mswin/i
-      if %w(amd64 x84_64).include? Config::CONFIG["host_cpu"]
+      if %w(amd64 x86_64).include? RbConfig::CONFIG["host_cpu"]
         '../../../vendor/swt/swt-win64'
       else
         '../../../vendor/swt/swt-win32'

--- a/lib/swt/minimal.rb
+++ b/lib/swt/minimal.rb
@@ -4,7 +4,7 @@ require 'swt/event_loop'
 require 'swt/cucumber_runner'
 
 module Swt
-  VERSION = "0.13" # also change in swt.gemspec
+  VERSION = "0.14" # also change in swt.gemspec
   
   import org.eclipse.swt.SWT
   

--- a/swt.gemspec
+++ b/swt.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "swt"
-  s.version     = "0.13" # also change in lib/swt/minimal.rb
+  s.version     = "0.14" # also change in lib/swt/minimal.rb
   s.platform    = "ruby"
   s.authors     = ["Daniel Lucraft"]
   s.email       = ["dan@fluentradical.com"]


### PR DESCRIPTION
This fix solves the following redcar blocker:

```
NameError: missing class or uppercase package name (`org.eclipse.swt.widgets.Display')
  get_proxy_or_package_under_package at org/jruby/javasupport/JavaUtilities.java:54
                      method_missing at file:/home/sebastien/.rvm/rubies/jruby-head/lib/jruby.jar!/jruby/java/java_package_module_template.rb:10
                             Widgets at /home/sebastien/.rvm/gems/jruby-head/gems/swt-0.13/lib/swt/minimal.rb:12
                                 Swt at /home/sebastien/.rvm/gems/jruby-head/gems/swt-0.13/lib/swt/minimal.rb:11
                              (root) at /home/sebastien/.rvm/gems/jruby-head/gems/swt-0.13/lib/swt/minimal.rb:6
                             require at org/jruby/RubyKernel.java:1018
                             require at /home/sebastien/.rvm/rubies/jruby-head/lib/ruby/shared/rubygems/custom_require.rb:60
                             require at /home/sebastien/.rvm/rubies/jruby-head/lib/ruby/shared/rubygems/custom_require.rb:55
                              (root) at /home/sebastien/dev/redcar/lib/redcar.rb:1
                  load_prerequisites at /home/sebastien/dev/redcar/lib/redcar.rb:145
                              (root) at ./redcar:28
```

It also fixes warning coming from `rbconfig`.
