### PR TITLE
TrayItem is added & updated the requires to require_relative

### DIFF
--- a/lib/swt.rb
+++ b/lib/swt.rb
@@ -1,3 +1,3 @@
 
-require 'swt/minimal'
-require 'swt/full'
+require_relative 'swt/minimal'
+require_relative 'swt/full'

--- a/lib/swt/full.rb
+++ b/lib/swt/full.rb
@@ -1,4 +1,4 @@
-require 'swt/swt_bot_extensions'
+require_relative 'swt_bot_extensions'
 
 module Swt
   import org.eclipse.swt.SWT
@@ -125,4 +125,4 @@ module JFace
   end
 end
 
-require 'swt/grid_data'
+require_relative 'grid_data'

--- a/lib/swt/minimal.rb
+++ b/lib/swt/minimal.rb
@@ -1,7 +1,7 @@
 
-require 'swt/jar_loader'
-require 'swt/event_loop'
-require 'swt/cucumber_runner'
+require_relative 'jar_loader'
+require_relative 'event_loop'
+require_relative 'cucumber_runner'
 
 module Swt
   VERSION = "0.13" # also change in swt.gemspec


### PR DESCRIPTION
Following are the changes:
1. TrayItem was missing. I added this to the list of imports.
2. I attempted to swt locally for a project. I see the use of require in swt refers to the files in LOCAL gem. This prevents me to use swt as git submodule since it doesn't take up my changes. So I went over and updated the `require` to `require_relative`. Please let me know if this is not appropriate. If so, I am interested to know the right approach for this problem.

Please consider to include these changes to the gem if ok.

Thanks!
ragu
