### PR TITLE
Fixing cpu detection

### DIFF
--- a/lib/swt/jar_loader.rb
+++ b/lib/swt/jar_loader.rb
@@ -2,7 +2,7 @@ require 'rbconfig'
 
 module Swt
 
-  X64_BIT_CPUS = %w(amd64 x84_64 x86_64)
+  X64_BIT_CPUS = %w(amd64 x86_64)
 
   def self.jar_path
     @jar_path ||= File.expand_path(relative_jar_path, __FILE__)


### PR DESCRIPTION
Hi,

this should fix cpu recognition on all OS - at least linux and MacOSX. I didn't quite notice that @wasnotrice also already fixed it for Linux (not just Max), in his PR so this relates to #3 - but well since I was at it I removed a little duplication and added a tiny bit of memoization to prevent a duplicated call (as I presume that cpu and OS don't change in between)

I'd appreciate a quick merge if it"s good :-)

Cheers,
Tobi
